### PR TITLE
Fix --test for --gemstone. Fix typo in --stormfront.

### DIFF
--- a/lib/options.rb
+++ b/lib/options.rb
@@ -41,7 +41,7 @@ class Parser
       :avalon,
       :frostbite,
       :genie,
-      :storrmfront,
+      :stormfront,
       :without_frontend,
       :wizard,
       # Logon
@@ -518,6 +518,10 @@ class Parser
 
     args.entryfile ||= "#{args.datadir}/entry.dat"
     
+    unless args.gemstone || args.dragonrealms || args.game
+      args.gemstone = true
+    end
+
     # TODO: Check for invalid combinations. For example, '-s -w' doesn't make sense.
     #if gamecode.gemstone
     #  if gamecode.platinum

--- a/lich.rbw
+++ b/lich.rbw
@@ -2365,8 +2365,8 @@ module Games
                 end
 
                 if @@autostarted and $_SERVERSTRING_ =~ /roomDesc/ and !@@cli_scripts
-                  if optios.start_scripts
-                    for script_name in optios.start_scripts
+                  if @options.start_scripts
+                    for script_name in @options.start_scripts
                       Script.start(script_name)
                     end
                   end
@@ -4781,6 +4781,8 @@ main_thread = Thread.new {
     #       the entry.dat file.
     # TODO: This can all be condesend down to a single match treating @options.gamecode as
     #       a regex against d[:game_code]
+    # TODO: This completely ignores d[:frontend] making --wizard and --stormfront options
+    #       meaningless for this code path.
     if @options.gemstone
       if @options.platinum
         data = entry_data.find { |d| (d[:char_name] == char_name) and (d[:game_code] == 'GSX') }

--- a/lich.rbw
+++ b/lich.rbw
@@ -4611,6 +4611,9 @@ if @options.sal
   end
 end
 
+# TODO: gs3.simutronics.net and storm.gs4.game.play.net both appear
+#       to be aliases to chimera.simutronics.com. This logic can
+#       probably be simplified especially due to fake_stormfront.
 if @options.game
   game_host = @options.game.host
   game_port = @options.game.port
@@ -4645,13 +4648,19 @@ elsif @options.gemstone
     end
   else
     $platinum = false
-    if @options.stormfront.stormfront
+    if @options.stormfront
       game_host = 'storm.gs4.game.play.net'
-      game_port = 10024
+      game_port = @options.test ? 10624 : 10024
       $frontend = 'stormfront'
     else
-      game_host = 'gs3.simutronics.net'
-      game_port = 4900
+      if @options.test
+        game_host = 'storm.gs4.game.play.net'
+        game_port = 10624
+      else
+        game_host = 'gs3.simutronics.net'
+        game_port = 4900
+      end
+
       if @options.avalon
         $frontend = 'avalon'
       else


### PR DESCRIPTION
* Fix typo in options.rb when using option --stormfront
* Fix automatic login to gemstone test instance by setting the correct port for the test instance
* Ensure we always default to GS unless
  - --dragonrealms or --fallen was passed, then use DragonRealms
  - an explicit server was passed with --game, then use that
